### PR TITLE
add gamerule for killers shuttle to spawn

### DIFF
--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -218,3 +218,11 @@
           max: 1
           pickPlayer: false
           
+# Security Shuttle
+- type: entity
+  parent: BaseGameRule
+  id: SecurityShuttleSpawn_KillerTamashi
+  components:
+    - type: RuleGrids
+    - type: LoadMapRule
+      gridPath: /Maps/_Starlight/Shuttles/KillerTamashi-SecShuttle.yml


### PR DESCRIPTION
this will just allow admins to spawn it in easier, nothing else.
should be fine even under the stipulation you received -- if not, they can just take it out of your PR 🤷 